### PR TITLE
Fix plugin installation directory for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Windows 環境では、[Visual Studio 2013 の Visual C++ 再頒布可能パッ�
 
 ここのプラグインを利用する最も簡単な方法は、同行しているビルド済みプラグインをそのまま利用することだと思います。
 
-`bin/{osx,win}/dwango_opentoonz_plugins.zip`がここで紹介しているプラグインをビルドしてzipに固めたものなので、これを展開して、中の.pluginファイルのうち利用したいものを `{Opentoonzのインストールされたディレクトリ}/plugins/` 以下にコピーしてください。OSXなら`/Applications/OpenToonz/OpenToonz_1.0_stuff/plugins/`、windowsなら`C:\OpenToonz stuff\plugins`であることが多いと思います。
+`bin/{osx,win}/dwango_opentoonz_plugins.zip`がここで紹介しているプラグインをビルドしてzipに固めたものなので、これを展開して、中の.pluginファイルのうち利用したいものを `{Opentoonzのインストールされたディレクトリ}/plugins/` 以下にコピーしてください。OSXなら`/Applications/OpenToonz/OpenToonz_1.0_stuff/plugins/`、windowsなら`C:\OpenToonz 1.0 stuff\plugins\`であることが多いと思います。
 
 この後OpenToonzを再起動すればプラグインが追加されますが、OpenCV3を利用しているため、そちらの準備ができていないとプラグインが認識されません。Opencv3については、以下のインストール方法に従ってください。
 


### PR DESCRIPTION
Fixed default opentoonz stuff directory, as mentioned in http://rikoubou.hatenablog.com/entry/2016/03/29/135907 .
