### PR TITLE
Add Linux definition to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if(APPLE)
     set(PLUGIN_UTILITY_LIB "${CMAKE_CURRENT_SOURCE_DIR}/opentoonz_plugin_utility/lib/${CMAKE_CFG_INTDIR}/libopentoonz_plugin_utility.a")
 endif(APPLE)
 
+if(UNIX AND NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(PLUGIN_UTILITY_LIB "${CMAKE_CURRENT_SOURCE_DIR}/opentoonz_plugin_utility/lib/${CMAKE_CFG_INTDIR}/libopentoonz_plugin_utility.a")
+endif(UNIX AND NOT APPLE)
+
 find_package(OpenCV REQUIRED)
 set(LIBS ${OpenCV_LIBS} ${PLUGIN_UTILITY_LIB})
 


### PR DESCRIPTION
Duplicate and edit the APPLE line for LINUX to build.
Related to opentoonz/opentoonz_plugin_utility#4 since opentoonz_plugin_utility is a submodule.
Actually it builds and OpenToonz doesn't seems to cry at startup.
I haven't checked if they works nor where to find them in OT, it's just build stuff actually.

```
plugin search directory:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins
walkDirectory_: /home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurChromaticAberration.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurConvolution.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurCurlNoise.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurMaskedC.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurMaskedD.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_BlurMaskedR.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_CoherentNoise.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_ComposeAdd.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_ComposeMul.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_ComposeOptical.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_Drip.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_ImageQuilting.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_Kaleidoscope.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_LightBloom.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_LightGlare.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_LightIncident.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_Paraffin.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_PencilHatching.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_Tiling.plugin
doLoad handle:(nil) path:/home/dashie/.local/share/OpenToonz/OpenToonz 1.0/plugins/DWANGO_WaveGlass.plugin
===== PluginLoadController::finished() =====
```
